### PR TITLE
Update to *ring* 0.9.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,15 @@ license = "MIT"
 name = "ruma-signatures"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma-signatures"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 base64 = "0.5.0"
 lazy_static = "0.2.8"
-ring = "0.7"
+ring = "0.9.4"
 serde = "1.0"
 serde_json = "1.0"
-untrusted = "0.3"
+untrusted = "0.5"
 url = "1.4"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,9 +342,9 @@ pub trait Verifier {
 impl KeyPair for Ed25519KeyPair {
     fn new(public_key: &[u8], private_key: &[u8], version: String) -> Result<Self, Error> {
         Ok(Ed25519KeyPair {
-            ring_key_pair: RingEd25519KeyPair::from_bytes(
-                private_key,
-                public_key,
+            ring_key_pair: RingEd25519KeyPair::from_seed_and_public_key(
+                untrusted::Input::from(private_key),
+                untrusted::Input::from(public_key),
             ).map_err(|_| Error::new("invalid key pair"))?,
             version: version,
         })
@@ -353,7 +353,7 @@ impl KeyPair for Ed25519KeyPair {
     fn sign(&self, message: &[u8]) -> Signature {
         Signature {
             algorithm: Algorithm::Ed25519,
-            signature: self.ring_key_pair.sign(message).as_slice().to_vec(),
+            signature: self.ring_key_pair.sign(message).as_ref().to_vec(),
             version: self.version.clone(),
         }
     }


### PR DESCRIPTION
'Before *ring* 0.9.3, it was possible to link multiple versions of *ring* into a program, e.g. if one version depended on *ring* 0.6 and another dependend on *ring* 0.9. Unfortunately, this doesn't work, because the linker doesn't know to how to link *ring*'s C/asm code correctly in that kind of situation. *ring* 0.9.3 added a flag to its Cargo.toml to tell the Rust toolchain to stop allowing multiple versions of *ring* to be linked into the same program, to prevent any problems this may cause.

*ring* 0.9.4 was released with an update to make some crates easier to update to 0.9.x.