### PR TITLE
Generate public/private keys for ed25519

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -78,16 +78,13 @@ static REFERENCE_HASH_FIELDS_TO_REMOVE: &[&str] = &["age_ts", "signatures", "uns
 /// A homeserver signs JSON with a key pair:
 ///
 /// ```rust
-/// const PUBLIC_KEY: &str = "XGX0JRS2Af3be3knz2fBiRbApjm2Dh61gXDJA8kcJNI";
-/// const PRIVATE_KEY: &str = "YJDBA9Xnr2sVqXD9Vj7XVUnmFZcZrlw8Md7kMW+3XA0";
+/// const PKCS8: &str = "MFMCAQEwBQYDK2VwBCIEINjozvdfbsGEt6DD+7Uf4PiJ/YvTNXV2mIPc/tA0T+6toSMDIQDdM+tpNzNWQM9NFpfgr4B9S7LHszOrVRp9NfKmeXS3aQ";
 ///
-/// let public_key = base64::decode_config(&PUBLIC_KEY, base64::STANDARD_NO_PAD).unwrap();
-/// let private_key = base64::decode_config(&PRIVATE_KEY, base64::STANDARD_NO_PAD).unwrap();
+/// let document = base64::decode_config(&PKCS8, base64::STANDARD_NO_PAD).unwrap();
 ///
 /// // Create an Ed25519 key pair.
 /// let key_pair = ruma_signatures::Ed25519KeyPair::new(
-///     &public_key,
-///     &private_key,
+///     &document,
 ///     "1".to_string(), // The "version" of the key.
 /// ).unwrap();
 ///
@@ -404,16 +401,13 @@ pub fn reference_hash(value: &Value) -> Result<String, Error> {
 /// # Examples
 ///
 /// ```rust
-/// const PUBLIC_KEY: &str = "XGX0JRS2Af3be3knz2fBiRbApjm2Dh61gXDJA8kcJNI";
-/// const PRIVATE_KEY: &str = "YJDBA9Xnr2sVqXD9Vj7XVUnmFZcZrlw8Md7kMW+3XA0";
+/// const PKCS8: &str = "MFMCAQEwBQYDK2VwBCIEINjozvdfbsGEt6DD+7Uf4PiJ/YvTNXV2mIPc/tA0T+6toSMDIQDdM+tpNzNWQM9NFpfgr4B9S7LHszOrVRp9NfKmeXS3aQ";
 ///
-/// let public_key = base64::decode_config(&PUBLIC_KEY, base64::STANDARD_NO_PAD).unwrap();
-/// let private_key = base64::decode_config(&PRIVATE_KEY, base64::STANDARD_NO_PAD).unwrap();
+/// let document = base64::decode_config(&PKCS8, base64::STANDARD_NO_PAD).unwrap();
 ///
 /// // Create an Ed25519 key pair.
 /// let key_pair = ruma_signatures::Ed25519KeyPair::new(
-///     &public_key,
-///     &private_key,
+///     &document,
 ///     "1".to_string(), // The "version" of the key.
 /// ).unwrap();
 ///

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -115,3 +115,13 @@ pub type PublicKeyMap = HashMap<String, PublicKeySet>;
 ///
 /// This is represented as a map from key ID to Base64-encoded signature.
 pub type PublicKeySet = HashMap<String, String>;
+
+#[cfg(test)]
+mod tests {
+    use super::Ed25519KeyPair;
+
+    #[test]
+    fn generate_key() {
+        Ed25519KeyPair::generate().unwrap();
+    }
+}


### PR DESCRIPTION
This copies a bit of Ring's internals from the provided Ed25519::generate() function to expose the seed (a 32-byte u8 vec) on it's own.

This is the most minimally-invasive way to generate a key. What ring recommends is using it's provided `generate` function, but that combines the public & private keys in the generated `Document` type. Unless we want to remove our own separation of those ideas, this is the way it needs to be done.